### PR TITLE
Support basic externalName Service Sync

### DIFF
--- a/control-plane/version/version.go
+++ b/control-plane/version/version.go
@@ -19,7 +19,7 @@ var (
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release
 	// such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = "invoca"
 )
 
 // GetHumanVersion composes the parts of the version in a way that's suitable


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Support basic `type: externalName` Service sync **into Consul**

### How I've tested this PR ###

Tests are passing (the related tests):
```
> go test -count=1 ./... -run TestServiceResource_                                                                         12:18:36
ok  	github.com/hashicorp/consul-k8s/control-plane/catalog/to-consul	2.450s
```
(`-count=1` is to disable caching)

I have the Consul binary locally but the full testing suite fails, mostly due to the `to-k8s/` code where `config.json` is set up with unsupported Consul configurations for the specific version of Consul at Invoca. Invoca doesn't use `to-k8s/` so that feels _okay right now_.

For an end-to-end example, this is running in one of the Kubernetes clusters in non-production and:
```
kubectl create service externalname hi-im-dan --external-name dan.pramann.us
```
yields:
```
2024-12-04T17:16:48.924Z [DEBUG] to-consul/controller: queue: op=add key=monitoring/hi-im-dan
2024-12-04T17:16:48.924Z [DEBUG] to-consul/controller: processing object: key=monitoring/hi-im-dan exists=true
2024-12-04T17:16:48.924Z [DEBUG] to-consul/source: [ServiceResource.Upsert] adding service to serviceMap: key=monitoring/hi-im-dan service="&Service{ObjectMeta:{hi-im-dan  monitoring  ab28dd7a-d28d-4368-8384-2cd903313ee5 420981411 0 2024-12-04 17:16:48 +0000 UTC <nil> <nil> map[app:hi-im-dan] map[] [] []  [{kubectl-create Update v1 2024-12-04 17:16:48 +0000 UTC FieldsV1 {\"f:metadata\":{\"f:labels\":{\".\":{},\"f:app\":{}}},\"f:spec\":{\"f:externalName\":{},\"f:selector\":{},\"f:sessionAffinity\":{},\"f:type\":{}}} }]},Spec:ServiceSpec{Ports:[]ServicePort{},Selector:map[string]string{app: hi-im-dan,},ClusterIP:,Type:ExternalName,ExternalIPs:[],SessionAffinity:None,LoadBalancerIP:,LoadBalancerSourceRanges:[],ExternalName:dan.pramann.us,ExternalTrafficPolicy:,HealthCheckNodePort:0,PublishNotReadyAddresses:false,SessionAffinityConfig:nil,IPFamilyPolicy:nil,ClusterIPs:[],IPFamilies:[],AllocateLoadBalancerNodePorts:nil,LoadBalancerClass:nil,InternalTrafficPolicy:nil,},Status:ServiceStatus{LoadBalancer:LoadBalancerStatus{Ingress:[]LoadBalancerIngress{},},Conditions:[]Condition{},},}"
2024-12-04T17:16:48.925Z [DEBUG] to-consul/source: [generateRegistrations] generating registration: key=monitoring/hi-im-dan
2024-12-04T17:16:48.925Z [DEBUG] to-consul/source: generated registration: key=monitoring/hi-im-dan service=hi-im-dan namespace="" instances=1
```
and:
![image](https://github.com/user-attachments/assets/837f55f3-4305-4d96-a049-938297b9161b)




### Checklist ###
- [x] Tests added
