### PR TITLE
Do not reap the world on restart

### DIFF
--- a/control-plane/catalog/to-consul/consul_node_services_client_ent_test.go
+++ b/control-plane/catalog/to-consul/consul_node_services_client_ent_test.go
@@ -327,7 +327,7 @@ func TestNamespacesNodeServicesClient_NodeServices(t *testing.T) {
 		}
 		t.Run(name, func(tt *testing.T) {
 			require := require.New(tt)
-			svr, err := testutil.NewTestServerConfigT(tt, nil)
+			svr, err := testutil.NewTestServerConfigT(tt, InvocaSpecificConsulConfig)
 			require.NoError(err)
 			defer svr.Stop()
 

--- a/control-plane/catalog/to-consul/consul_node_services_client_test.go
+++ b/control-plane/catalog/to-consul/consul_node_services_client_test.go
@@ -157,7 +157,7 @@ func TestPreNamespacesNodeServicesClient_NodeServices(t *testing.T) {
 	for name, c := range cases {
 		t.Run(name, func(tt *testing.T) {
 			require := require.New(tt)
-			svr, err := testutil.NewTestServerConfigT(tt, nil)
+			svr, err := testutil.NewTestServerConfigT(tt, InvocaSpecificConsulConfig)
 			require.NoError(err)
 			defer svr.Stop()
 

--- a/control-plane/catalog/to-consul/syncer.go
+++ b/control-plane/catalog/to-consul/syncer.go
@@ -263,6 +263,10 @@ func (s *ConsulSyncer) watchService(ctx context.Context, name, namespace string)
 	s.Log.Info("starting service watcher", "service-name", name, "service-consul-namespace", namespace)
 	defer s.Log.Info("stopping service watcher", "service-name", name, "service-consul-namespace", namespace)
 
+	s.Log.Debug("[watchService] waiting for services to be populated before enabling watching a service")
+	<-s.WaitForServiceSnapshotToBePopulatedCh
+	s.Log.Debug("[watchService] services have been populated at startup, watching")
+
 	for {
 		select {
 		// Quit if our context is over

--- a/control-plane/catalog/to-consul/syncer_ent_test.go
+++ b/control-plane/catalog/to-consul/syncer_ent_test.go
@@ -15,7 +15,7 @@ import (
 func TestConsulSyncer_ConsulNamespaces(t *testing.T) {
 	t.Parallel()
 
-	a, err := testutil.NewTestServerConfigT(t, nil)
+	a, err := testutil.NewTestServerConfigT(t, InvocaSpecificConsulConfig)
 	require.NoError(t, err)
 	defer a.Stop()
 
@@ -66,7 +66,7 @@ func TestConsulSyncer_ConsulNamespaces(t *testing.T) {
 func TestConsulSyncer_ReapConsulNamespace(t *testing.T) {
 	t.Parallel()
 
-	a, err := testutil.NewTestServerConfigT(t, nil)
+	a, err := testutil.NewTestServerConfigT(t, InvocaSpecificConsulConfig)
 	require.NoError(t, err)
 	defer a.Stop()
 
@@ -135,7 +135,7 @@ func TestConsulSyncer_ReapConsulNamespace(t *testing.T) {
 func TestConsulSyncer_reapServiceInstanceNamespacesEnabled(t *testing.T) {
 	t.Parallel()
 
-	a, err := testutil.NewTestServerConfigT(t, nil)
+	a, err := testutil.NewTestServerConfigT(t, InvocaSpecificConsulConfig)
 	require.NoError(t, err)
 	defer a.Stop()
 

--- a/control-plane/catalog/to-consul/syncer_test.go
+++ b/control-plane/catalog/to-consul/syncer_test.go
@@ -26,7 +26,8 @@ func TestConsulSyncer_register(t *testing.T) {
 	require := require.New(t)
 
 	// Set up server, client, syncer
-	a, err := testutil.NewTestServerConfigT(t, nil)
+
+	a, err := testutil.NewTestServerConfigT(t, InvocaSpecificConsulConfig)
 	require.NoError(err)
 	defer a.Stop()
 
@@ -72,7 +73,7 @@ func TestConsulSyncer_reapServiceInstance(t *testing.T) {
 			require := require.New(t)
 
 			// Set up server, client, syncer
-			a, err := testutil.NewTestServerConfigT(t, nil)
+			a, err := testutil.NewTestServerConfigT(t, InvocaSpecificConsulConfig)
 			require.NoError(err)
 			defer a.Stop()
 
@@ -137,7 +138,7 @@ func TestConsulSyncer_reapService(t *testing.T) {
 	for _, k8sNS := range sourceK8sNamespaceAnnotations {
 		t.Run(k8sNS, func(tt *testing.T) {
 			// Set up server, client, syncer
-			a, err := testutil.NewTestServerConfigT(tt, nil)
+			a, err := testutil.NewTestServerConfigT(tt, InvocaSpecificConsulConfig)
 			require.NoError(tt, err)
 			defer a.Stop()
 
@@ -185,7 +186,7 @@ func TestConsulSyncer_reapService(t *testing.T) {
 func TestConsulSyncer_noReapingUntilInitialSync(t *testing.T) {
 	t.Parallel()
 
-	a, err := testutil.NewTestServerConfigT(t, nil)
+	a, err := testutil.NewTestServerConfigT(t, InvocaSpecificConsulConfig)
 	require.NoError(t, err)
 	defer a.Stop()
 	client, err := api.NewClient(&api.Config{

--- a/control-plane/catalog/to-consul/syncer_test.go
+++ b/control-plane/catalog/to-consul/syncer_test.go
@@ -290,6 +290,9 @@ func testConsulSyncer(client *api.Client) (*ConsulSyncer, func()) {
 // testConsulSyncerWithConfig starts a consul syncer that can be configured
 // prior to starting via the configurator method.
 func testConsulSyncerWithConfig(client *api.Client, configurator func(*ConsulSyncer)) (*ConsulSyncer, func()) {
+	waitForInitialServicesCh := make(chan bool)
+	close(waitForInitialServicesCh)
+
 	s := &ConsulSyncer{
 		Client:            client,
 		Log:               hclog.Default(),
@@ -300,6 +303,7 @@ func testConsulSyncerWithConfig(client *api.Client, configurator func(*ConsulSyn
 		ConsulNodeServicesClient: &PreNamespacesNodeServicesClient{
 			Client: client,
 		},
+		WaitForServiceSnapshotToBePopulatedCh: waitForInitialServicesCh,
 	}
 	configurator(s)
 	s.init()

--- a/control-plane/catalog/to-consul/testing.go
+++ b/control-plane/catalog/to-consul/testing.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"github.com/hashicorp/consul/sdk/testutil"
 	"sync"
 
 	"github.com/hashicorp/consul/api"
@@ -26,4 +27,9 @@ func (s *testSyncer) Sync(rs []*api.CatalogRegistration) {
 
 func newTestSyncer() *testSyncer {
 	return &testSyncer{}
+}
+
+// callback to remove the peering key from the config generated, avoids "invalid config key peering"
+func InvocaSpecificConsulConfig(cfg *testutil.TestServerConfig) {
+	cfg.Peering = nil
 }

--- a/control-plane/subcommand/sync-catalog/command.go
+++ b/control-plane/subcommand/sync-catalog/command.go
@@ -278,7 +278,7 @@ func (c *Command) Run(args []string) int {
 			EnableK8SNSMirroring:                  c.flagEnableK8SNSMirroring,
 			K8SNSMirroringPrefix:                  c.flagK8SNSMirroringPrefix,
 			ConsulNodeName:                        c.flagConsulNodeName,
-			WaitForServiceSnapshotToBePopulatedCh: waitForInitalServicesCh,
+			WaitForInitialServicesToBePopulatedCh: waitForInitalServicesCh,
 		}
 
 		resource.PopulateInitialServices()


### PR DESCRIPTION
### Changes proposed in this PR ###  
- Block `watchService()` goroutines until we've done an initial population of all services
- Block `watchReapableServices()` goroutine until we've done an initial population of all services

### Notes ###

* I did include some changes to tests to support me running the tests with a specific setup, we can back those out if we want/choose.