### PR TITLE
TECH-17408: Start healthcheck server earlier

### DIFF
--- a/control-plane/subcommand/sync-catalog/command.go
+++ b/control-plane/subcommand/sync-catalog/command.go
@@ -210,6 +210,18 @@ func (c *Command) Run(args []string) int {
 		}
 	}
 
+	// Start healthcheck handler
+	go func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/health/ready", c.handleReady)
+		var handler http.Handler = mux
+
+		c.UI.Info(fmt.Sprintf("Listening on %q...", c.flagListen))
+		if err := http.ListenAndServe(c.flagListen, handler); err != nil {
+			c.UI.Error(fmt.Sprintf("Error listening: %s", err))
+		}
+	}()
+
 	// Convert allow/deny lists to sets
 	allowSet := flags.ToSet(c.flagAllowK8sNamespacesList)
 	denySet := flags.ToSet(c.flagDenyK8sNamespacesList)
@@ -328,18 +340,6 @@ func (c *Command) Run(args []string) int {
 			ctl.Run(ctx.Done())
 		}()
 	}
-
-	// Start healthcheck handler
-	go func() {
-		mux := http.NewServeMux()
-		mux.HandleFunc("/health/ready", c.handleReady)
-		var handler http.Handler = mux
-
-		c.UI.Info(fmt.Sprintf("Listening on %q...", c.flagListen))
-		if err := http.ListenAndServe(c.flagListen, handler); err != nil {
-			c.UI.Error(fmt.Sprintf("Error listening: %s", err))
-		}
-	}()
 
 	select {
 	// Unexpected exit


### PR DESCRIPTION
This PR makes a small adjustment to the part of the code that initializes a health check server on port 8080. When queried, the health check server will attempt to reach out to Consul and ask who the leader of the cluster is. We use this endpoint to set up probes as part of our `consul-sync` Kubernetes Deployment.

The problem with the above is that, with the addition of `resource.PopulateInitialServices()` coming from https://github.com/Invoca/consul-k8s/pull/2, we are taking a variable (but longer) amount of time to get to the point in the code where we would usually initialize the health check server. This is not ideal, because if we take too long, the Kubernetes probes will cause our Pods to restart.

In this PR, we set up the health check server much earlier — just after setting up the Consul client that is necessary in order to perform the health checks.
