### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,4 +14,4 @@ spec:
   type: tool
   lifecycle: production
   owner: sre-core
-  # system: TODO — see https://github.com/Invoca/backstage-catalog
+  system: kubernetes-platform

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: consul-k8s
+  title: consul-k8s
+  description: "First-class support for Consul and Kubernetes. Run Consul on Kubernetes, integrate Connect, sync services, and more."
+  tags:
+    - go
+  annotations:
+    backstage.io/source-location: url:https://github.com/Invoca/consul-k8s/
+    github.com/project-slug: Invoca/consul-k8s
+    buildkite.com/project-slug: invoca/consul-k8s
+spec:
+  type: tool
+  lifecycle: production
+  owner: sre-core
+  # system: TODO — see https://github.com/Invoca/backstage-catalog


### PR DESCRIPTION
## Add Backstage `catalog-info.yaml`

Registers this repo in the [Invoca Backstage catalog](https://backstage.invoca.net).

### What was auto-generated
- **type**: `tool` (inferred from repo name/language)
- **owner**: `sre-core`
- **system**: `kubernetes-platform`

### Please review before merging
- [ ] `spec.owner` is correct
- [ ] `spec.system` is set (see [taxonomy](https://github.com/Invoca/backstage-catalog))
- [ ] `metadata.description` is accurate
- [ ] Add `dependsOn`, `providesApis`, or `consumesApis` if relevant

See [voice-agent](https://github.com/Invoca/voice-agent/tree/main/.backstage) for a fully-built example.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
